### PR TITLE
Limit EarthWorks externals to used components

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -115,22 +115,6 @@ repo_url = https://github.com/EarthWorksOrg/mpas-framework.git
 local_path = components/mpas-framework
 required = True
 
-[fms]
-tag = fi_20220425
-protocol = git
-repo_url = https://github.com/ESCOMP/FMS_interface
-local_path = libraries/FMS
-externals = Externals_FMS.cfg
-required = False
-
-[mom]
-tag = mi_220624
-protocol = git
-repo_url = https://github.com/ESCOMP/MOM_interface
-local_path = components/mom
-externals = Externals.cfg
-required = False
-
 [mosart]
 tag = mosart1_0_45
 protocol = git
@@ -138,41 +122,11 @@ repo_url = https://github.com/ESCOMP/MOSART
 local_path = components/mosart
 required = True
 
-[pop]
-tag = cesm_pop_2_1_20220322
-protocol = git
-repo_url = https://github.com/ESCOMP/POP2-CESM
-local_path = components/pop
-externals = Externals_POP.cfg
-required = True
-
 [pycect]
 tag = 3.2.2
 protocol = git
 repo_url = https://github.com/NCAR/PyCECT
 local_path = tools/statistical_ensemble_test/pyCECT
-required = False
-
-[rtm]
-tag = rtm1_0_78 
-protocol = git
-repo_url = https://github.com/ESCOMP/RTM
-local_path = components/rtm
-required = True
-
-[ww3]
-tag = ww3_220322
-protocol = git
-repo_url = https://github.com/ESCOMP/WW3-CESM
-local_path = components/ww3
-required = True
-
-[ww3dev]
-tag = main_0.0.2
-protocol = git
-repo_url = https://github.com/ESCOMP/WW3_interface
-local_path = components/ww3dev
-externals = Externals.cfg
 required = False
 
 [externals_description]


### PR DESCRIPTION
Unused code adds to the model size and complexity without benefit. This PR removes FMS, MOM, RTM, WW3, and WW3dev from Externals.cfg.