### PR TITLE
Ensure use of EarthWorksOrgs externals for develop branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,14 +1,14 @@
 [ccs_config]
 branch = earthworks
 protocol = git
-repo_url = https://github.com/gdicker1/ccs_config_cesm.git
+repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cam]
 branch = earthworks
 protocol = git
-repo_url = https://github.com/gdicker1/CAM
+repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True
@@ -31,7 +31,7 @@ required = True
 [cmeps]
 branch = earthworks
 protocol = git
-repo_url = https://github.com/gdicker1/CMEPS.git
+repo_url = https://github.com/EarthWorksOrg/CMEPS.git
 local_path = components/cmeps
 required = True
 
@@ -74,7 +74,7 @@ required = True
 [cime]
 branch = earthworks
 protocol = git
-repo_url = https://github.com/gdicker1/cime
+repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime
 required = True
 
@@ -97,21 +97,21 @@ required = True
 [mpas-ocean]
 branch = main
 protocol = git
-repo_url = https://github.com/dazlich/mpas-ocean.git
+repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
 branch = main
 protocol = git
-repo_url = https://github.com/dazlich/mpas-seaice.git
+repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 
 [mpas-framework]
 branch = main
 protocol = git
-repo_url = https://github.com/dazlich/mpas-framework.git
+repo_url = https://github.com/EarthWorksOrg/mpas-framework.git
 local_path = components/mpas-framework
 required = True
 


### PR DESCRIPTION
This avoids any mishaps due to personal ownership of codebases and hopefully consolidates where work occurs. Externals affected by this are CCS_Configs, CMEPS, CAM, CIME, MPAS-Ocean, MPAS-SeaIce, and MPAS-Framework.