### PR TITLE
Replace branches with tags for EarthWorksOrg externals

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,12 +1,12 @@
 [ccs_config]
-branch = earthworks
+tag = ccs_config-ew0.1.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cam]
-branch = earthworks
+tag = cam-ew0.1.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam
@@ -29,7 +29,7 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-branch = earthworks
+tag = cmeps-ew0.1.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CMEPS.git
 local_path = components/cmeps
@@ -72,7 +72,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-branch = earthworks
+tag = cime-ew0.1.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime
@@ -95,21 +95,21 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-branch = main
+tag = mpaso-ew0.1.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-branch = main
+tag = mpassi-ew0.1.007
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 
 [mpas-framework]
-branch = main
+tag = mpasfrwk-ew0.1.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-framework.git
 local_path = components/mpas-framework


### PR DESCRIPTION
This affects the ccs_configs, cam, cmeps, cime, mpas-ocean, mpas-seaice, and mpas-framework externals and introduces no code or science changes.