### PR TITLE
Update mpas-framework to enable FullyCoupled compset

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -109,7 +109,7 @@ local_path = components/mpas-seaice
 required = True
 
 [mpas-framework]
-tag = mpasfrwk-ew0.1.001
+tag = mpasfrwk-ew0.1.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-framework.git
 local_path = components/mpas-framework


### PR DESCRIPTION
To get the fully coupled model to run the mpas-framework external has been modified to match more closely to the MPAS-A framework.