### PR TITLE
Add EarthWorks Diagnostics as an external

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -129,5 +129,12 @@ repo_url = https://github.com/NCAR/PyCECT
 local_path = tools/statistical_ensemble_test/pyCECT
 required = False
 
+[ewms-diags]
+branch = main
+protocol = git
+repo_url = https://github.com/areanddee/EarthWorks_diags
+local_path = tools/ewms-diags
+required = True
+
 [externals_description]
 schema_version = 1.0.01


### PR DESCRIPTION
This PR incorporates the initial version of another important part of the EarthWorks project: our analysis scripts. Currently this external only contains scripts that produce plots for FHS94 and FKESSLER compsets.