### PR TITLE
Update externals to allow FullyCoupled compset to build with GNU

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -72,7 +72,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime-ew0.1.001
+tag = cime-ew0.1.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime
@@ -95,14 +95,14 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-tag = mpaso-ew0.1.002
+tag = mpaso-ew0.1.003
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-tag = mpassi-ew0.1.007
+tag = mpassi-ew0.1.008
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice


### PR DESCRIPTION
The externals' tag numbers are being incremented by one to incorporate recent Pull Requests.

Affected EarthWorksOrg externals and PR number:
- mpas-ocean    PR#1
- mpas-seaice   PR#1
- cime                 PR#1