### PR TITLE
Update cime and ccs_configs externals for version 1 release

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -130,9 +130,9 @@ local_path = tools/statistical_ensemble_test/pyCECT
 required = False
 
 [ewms-diags]
-branch = main
+tag = diags-ew0.1.000
 protocol = git
-repo_url = https://github.com/areanddee/EarthWorks_diags
+repo_url = https://github.com/EarthWorksOrg/EarthWorks_diags
 local_path = tools/ewms-diags
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -72,7 +72,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime-ew0.1.002
+tag = cime-ew0.1.003
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = ccs_config-ew0.1.001
+tag = ccs_config-ew0.1.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config


### PR DESCRIPTION
Incorporate changes in externals.

- cime: apply unoptimized GNU build flags to only 1 file in MPAS-SI
- ccs_configs: add Gust as a machine
- ewms_diags: point to the EarthWorksOrg fork instead