### PR TITLE
Update externals based on CESM tag 'cesm2_3_alpha16d' and add default files

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -95,14 +95,14 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-tag = mpaso-ew1.0.001
+tag = mpaso-ew1.0.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-tag = mpassi-ew1.0.000
+tag = mpassi-ew1.0.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,12 +1,12 @@
 [ccs_config]
-tag = ccs_config-ew1.0.002
+tag = ccs_config-ew1.0.004
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cam]
-tag = cam-ew1.0.002
+tag = cam-ew1.0.003
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam
@@ -21,7 +21,7 @@ local_path = components/cice5
 required = True
 
 [cice6]
-tag = cesm_cice6_4_1_8
+tag = cesm_cice6_4_1_10
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE
 local_path = components/cice
@@ -29,14 +29,14 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-tag = cmeps-ew1.0.002
+tag = cmeps-ew1.0.003
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps1.0.14
+tag = cdeps1.0.21
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -44,7 +44,7 @@ externals = Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl77.0.5
+tag = cpl77.0.6
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
@@ -65,21 +65,21 @@ local_path = libraries/mct
 required = True
 
 [parallelio]
-tag = pio2_5_10
+tag = pio2_6_2
 protocol = git
 repo_url = https://github.com/NCAR/ParallelIO
 local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime-ew1.0.002
+tag = cime-ew1.0.003
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime
 required = True
 
 [cism]
-tag = cismwrap_2_1_95
+tag = cismwrap_2_1_96
 protocol = git
 repo_url = https://github.com/ESCOMP/CISM-wrapper
 local_path = components/cism
@@ -87,7 +87,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm-ew1.0.000
+tag = ctsm-ew1.0.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CTSM
 local_path = components/clm

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,7 +6,7 @@ local_path = ccs_config
 required = True
 
 [cam]
-tag = cam-ew1.0.003
+tag = cam-ew1.0.004
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam
@@ -87,7 +87,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm-ew1.0.001
+tag = ctsm-ew1.0.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CTSM
 local_path = components/clm

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -87,9 +87,9 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm5.1.dev123
+tag = ctsm-ew1.0.000
 protocol = git
-repo_url = https://github.com/ESCOMP/CTSM
+repo_url = https://github.com/EarthWorksOrg/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = ccs_config-ew1.0.004
+tag = ccs_config-ew1.0.005
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config


### PR DESCRIPTION
Advance the tags used in Externals.cfg to match with the versions used in ESCOMP/CESM tag 'cesm2_3_alpha16d'.

EXCEPT: cam based on cam6_3_124 and not cam6_3_125