### PR TITLE
Update mpas-* and ccs_configs externals

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = ccs_config-ew1.0.005
+tag = ccs_config-ew1.0.006
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
@@ -95,21 +95,21 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-tag = mpaso-ew1.0.002
+tag = mpaso-ew1.0.003
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-tag = mpassi-ew1.0.001
+tag = mpassi-ew1.0.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 
 [mpas-framework]
-tag = mpasfrwk-ew1.0.000
+tag = mpasfrwk-ew1.0.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-framework.git
 local_path = components/mpas-framework


### PR DESCRIPTION
- mpas-ocean: Update default io_type to "pnetcdf,cdf5" for oQU meshes
- mpas-seaice: Update default io_type to "pnetcdf,cdf5" for oQU meshes. Also fix intel compilation
- mpas-framework: Add logic to print PIO error messages when bad return values are given
- ccs_config: Add grids for river-runoff with mpas-ocean