### PR TITLE
Incorporate EarthWorksOrg/CAM PR #10

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,7 +6,7 @@ local_path = ccs_config
 required = True
 
 [cam]
-tag = cam-ew2.0.000
+tag = cam-ew2.0.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam


### PR DESCRIPTION
Urgent fix to allow new copies of EarthWorks to be fully checked out.

More info: [EarthWorksOrg/CAM Issue #9](https://github.com/EarthWorksOrg/CAM/issues/9), [EarthWorksOrg/CAM PR #10](https://github.com/EarthWorksOrg/CAM/pull/10)