### PR TITLE
Post cesm2_3_alpha17a Updates

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = ccs_config-ew2.0.001
+tag = ccs_config-ew2.0.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -95,21 +95,21 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-tag = mpaso-ew2.0.000
+tag = mpaso-ew2.0.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-tag = mpassi-ew2.0.001
+tag = mpassi-ew2.0.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 
 [mpas-framework]
-tag = mpasfrwk-ew2.0.000
+tag = mpasfrwk-ew2.0.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-framework.git
 local_path = components/mpas-framework

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,7 +6,7 @@ local_path = ccs_config
 required = True
 
 [cam]
-tag = cam-ew2.0.002
+tag = cam-ew2.0.003
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam
@@ -72,7 +72,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime-ew2.0.001
+tag = cime-ew2.0.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime
@@ -102,7 +102,7 @@ local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-tag = mpassi-ew2.0.000
+tag = mpassi-ew2.0.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice


### PR DESCRIPTION
This PR moves CAM up to tag cam6_3_145 while adding a patch for NVHPC compilers, moving CIME up to tag cime6.0.0182, and brings in recent changes to mpas-seaice that fix Intel OneAPI builds.