### PR TITLE
Fix "Multiple definition" Error for GPU builds of compsets using multiple MPAS cores

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -95,21 +95,24 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-tag = mpaso-ew2.1.000
+#tag = mpaso-ew2.1.000
+branch = framework-ext-refs
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-tag = mpassi-ew2.1.001
+#tag = mpaso-ew2.1.001
+branch = framework-ext-refs
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 
 [mpas-framework]
-tag = mpasfrwk-ew2.1.001
+#tag = mpaso-ew2.1.001
+branch = framework-ext-refs
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-framework.git
 local_path = components/mpas-framework

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -95,24 +95,21 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-#tag = mpaso-ew2.1.000
-branch = framework-ext-refs
+tag = mpaso-ew2.1.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-#tag = mpaso-ew2.1.001
-branch = framework-ext-refs
+tag = mpassi-ew2.1.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 
 [mpas-framework]
-#tag = mpaso-ew2.1.001
-branch = framework-ext-refs
+tag = mpasfrwk-ew2.1.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/mpas-framework.git
 local_path = components/mpas-framework


### PR DESCRIPTION
This PR incorporates changes in mpas-framework to the module names and changes to the buildlib scripts of mpas-ocean and mpas-seaice. All modules in mpas-framework source files begin with `MPASAOS` which the buidlib scripts replace (with `mpass` for mpas-seaice and `mpaso` for mpas-ocean) to create unique files and module names for mpas-seaice and mpas-ocean to use in their builds.

Fixes #36 but preserves compilation of 3 copies of "shared MPAS framework" routines.