### PR TITLE
Update Derecho config to use NVHPC/24.3

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,6 @@
 [ccs_config]
-tag = ccs_config-ew2.1.000
+# tag = ccs_config-ew2.1.000
+branch = update/upstream_derecho_nvhpc24.3
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
@@ -72,7 +73,8 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime-ew2.1.000
+# tag = cime-ew2.1.000
+branch = update/upstream_derecho_nvhpc24.3
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,6 +1,5 @@
 [ccs_config]
-# tag = ccs_config-ew2.1.000
-branch = update/upstream_derecho_nvhpc24.3
+tag = ccs_config-ew2.1.002
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
@@ -73,8 +72,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-# tag = cime-ew2.1.000
-branch = update/upstream_derecho_nvhpc24.3
+tag = cime-ew2.1.001
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime


### PR DESCRIPTION
Incorporate changes to EWOrg/ccs_config_cesm to use the `ncarenv/23.09` software stack and `nvhpc/24.3` on the Derecho supercomputer.