### PR TITLE
Enable use of create_test workflow

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,9 @@
 [ccs_config]
-tag = ccs_config-ew2.1.002
+# tag = ccs_config-ew2.1.002
+branch = fix_lowres_oQU
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+repo_url = https://github.com/gdicker1/ccs_config_cesm.git
+# repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
@@ -102,9 +104,11 @@ local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-tag = mpassi-ew2.1.003
+branch = configdt_highresgrids
+# tag = mpassi-ew2.1.003
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
+repo_url = https://github.com/gdicker1/mpas-seaice.git
+# repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,18 +1,14 @@
 [ccs_config]
-# tag = ccs_config-ew2.1.002
-branch = fix_lowres_oQU
+tag = ccs_config-ew2.1.003
 protocol = git
-repo_url = https://github.com/gdicker1/ccs_config_cesm.git
-# repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cam]
-branch = update/ew_mpasa_timesteps
-# tag = cam-ew2.1.002
+tag = cam-ew2.1.003
 protocol = git
-repo_url = https://github.com/gdicker1/CAM
-# repo_url = https://github.com/EarthWorksOrg/CAM
+repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True
@@ -33,11 +29,9 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-branch = ew_atmcpl_intervals
-# tag = cmeps-ew2.1.000
+tag = cmeps-ew2.1.001
 protocol = git
-repo_url = https://github.com/gdicker1/CMEPS.git
-# repo_url = https://github.com/EarthWorksOrg/CMEPS.git
+repo_url = https://github.com/EarthWorksOrg/CMEPS.git
 local_path = components/cmeps
 required = True
 
@@ -101,20 +95,16 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-branch = configdt_highresgrids
-# tag = mpaso-ew2.1.001
+tag = mpaso-ew2.1.002
 protocol = git
-repo_url = https://github.com/gdicker1/mpas-ocean.git
-# repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
+repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-branch = configdt_highresgrids
-# tag = mpassi-ew2.1.003
+tag = mpassi-ew2.1.004
 protocol = git
-repo_url = https://github.com/gdicker1/mpas-seaice.git
-# repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
+repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,9 +8,11 @@ local_path = ccs_config
 required = True
 
 [cam]
-tag = cam-ew2.1.002
+branch = update/ew_mpasa_timesteps
+# tag = cam-ew2.1.002
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/CAM
+repo_url = https://github.com/gdicker1/CAM
+# repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True
@@ -31,9 +33,11 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-tag = cmeps-ew2.1.000
+branch = ew_atmcpl_intervals
+# tag = cmeps-ew2.1.000
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/CMEPS.git
+repo_url = https://github.com/gdicker1/CMEPS.git
+# repo_url = https://github.com/EarthWorksOrg/CMEPS.git
 local_path = components/cmeps
 required = True
 
@@ -97,9 +101,11 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-tag = mpaso-ew2.1.001
+branch = configdt_highresgrids
+# tag = mpaso-ew2.1.001
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
+repo_url = https://github.com/gdicker1/mpas-ocean.git
+# repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -42,6 +42,18 @@
     <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_SROF_SGLC_SWAV</lname>
   </compset>
 
+  <!-- Like F2000climo, but replace CICE%PRES with MPASSI%PRES -->
+  <compset>
+    <alias>F2000climo-EW</alias>
+    <lname>2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+  </compset>
+
+  <!-- Like FullyCoupled-EW, but with MOSART river -->
+  <compset>
+    <alias>B2000-EW</alias>
+    <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
   <!-- END EarthWorks specific compsets -->
 
   <!-- 1850 compsets Default, Mosart, Wave for CESM2 -->
@@ -123,3 +135,8 @@
   </entries>
 
 </compsets>
+
+
+
+
+

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -36,6 +36,14 @@
     - grid  (optional regular expression match for grid to work with the compset)
   </help>
 
+  <!-- EarthWorks specific compsets -->
+  <compset>
+    <alias>FullyCoupled-EW</alias>
+    <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <!-- END EarthWorks specific compsets -->
+
   <!-- 1850 compsets Default, Mosart, Wave for CESM2 -->
 
   <compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -36,26 +36,6 @@
     - grid  (optional regular expression match for grid to work with the compset)
   </help>
 
-  <!-- EarthWorks specific compsets -->
-  <compset>
-    <alias>FullyCoupled-EW</alias>
-    <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_SROF_SGLC_SWAV</lname>
-  </compset>
-
-  <!-- Like F2000climo, but replace CICE%PRES with MPASSI%PRES -->
-  <compset>
-    <alias>F2000climo-EW</alias>
-    <lname>2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
-  </compset>
-
-  <!-- Like FullyCoupled-EW, but with MOSART river -->
-  <compset>
-    <alias>B2000-EW</alias>
-    <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <!-- END EarthWorks specific compsets -->
-
   <!-- 1850 compsets Default, Mosart, Wave for CESM2 -->
 
   <compset>
@@ -119,6 +99,26 @@
   <compset>
      <alias>J1850G</alias>
      <lname>1850_DATM%CRUv7_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM2%GRIS-EVOLVE_SWAV</lname>
+  </compset>
+
+  <!-- EarthWorks specific compsets -->
+       MPAS-ocean and/or MPAS-seaice couplings -->
+
+  <!-- F2000climo, with MPASSI%PRES -->
+  <compset>
+     <alias>F2000climoEW</alias>
+     <lname>2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+  </compset>
+
+  <compset>
+      <alias>FullyCoupledEW</alias>
+      <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <!-- Like FullyCoupledEW, but with MOSART river -->
+  <compset>
+     <alias>CHAOS2000</alias>
+     <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <entries>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -1,8 +1,50 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="FHS94" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:10:00 </option>
+    </options>
+  </test>
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="FKESSLER" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="QPC6" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="F2000climo" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
   <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupled-EW" testmods="earthworks/fullycoupled">
     <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
       <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00:00 </option>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<testlist version="2.0">
+  <test name="SMS_P128_Vnuopc" grid="mpasa480_oQU480" compset="FullyCoupled-EW" testmods="earthworks/fullycoupled">
+    <machines>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+      <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi</option>
+    </options>
+  </test>
+</testlist>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="SMS_P128_Vnuopc" grid="mpasa480_oQU480" compset="FullyCoupled-EW" testmods="earthworks/fullycoupled">
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupled-EW" testmods="earthworks/fullycoupled">
     <machines>
       <machine name="derecho" compiler="intel" category="ew-pr"/>
     </machines>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -13,8 +13,6 @@
   <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FKESSLER" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
-      <machine name="derecho" compiler="intel" category="ew-pr"/>
-      <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
       <option name="wallclock"> 00:05:00 </option>
@@ -23,8 +21,6 @@
   <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="QPC6" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
-      <machine name="derecho" compiler="intel" category="ew-pr"/>
-      <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -33,8 +29,6 @@
   <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="F2000climo" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
-      <machine name="derecho" compiler="intel" category="ew-pr"/>
-      <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -36,7 +36,7 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
-  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupled-EW" testmods="earthworks/fullycoupled">
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupled-EW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
       <machine name="derecho" compiler="intel" category="ew-pr"/>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="FHS94" >
+  <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
       <machine name="derecho" compiler="intel" category="ew-pr"/>
@@ -10,7 +10,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="FKESSLER" >
+  <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FKESSLER" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
       <machine name="derecho" compiler="intel" category="ew-pr"/>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
+
+  <!-- ew-pr Tests to run for the EW PR process -->
   <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
@@ -43,6 +45,65 @@
     <options>
       <option name="wallclock"> 00:10:00 </option>
       <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi</option>
+    </options>
+  </test>
+
+  <!-- ew-ver Tests to run for verification runs --> 
+  <test name="SMS_Ld1200_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94">
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-ver"/>
+      <machine name="derecho" compiler="intel" category="ew-ver"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 10:00:00 </option>
+      <option name="comment">EarthWorks run of FHS94 to generate plots for days 200 to 1200</option>
+    </options>
+  </test>
+
+  <!-- ew-rel Tests to run while creating a release -->
+  <test name="ERP_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupled-EW">
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
+      <machine name="derecho" compiler="intel" category="ew-rel"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:15:00 </option>
+    </options>
+  </test>
+  <test name="ERP_Vnuopc" grid="mpasa060_oQU060" compset="FullyCoupled-EW">
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
+      <machine name="derecho" compiler="intel" category="ew-rel"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:30:00 </option>
+    </options>
+  </test>
+  <test name="ERP_Vnuopc" grid="mpasa030_oQU030" compset="FullyCoupled-EW">
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
+      <machine name="derecho" compiler="intel" category="ew-rel"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
+  <test name="ERP_Vnuopc" grid="mpasa015z58_oQU015" compset="FullyCoupled-EW">
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
+      <machine name="derecho" compiler="intel" category="ew-rel"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
+  <test name="ERP_Vnuopc" grid="mpasa120z58_oQU120" compset="FullyCoupled-EW">
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
+      <machine name="derecho" compiler="intel" category="ew-rel"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
     </options>
   </test>
 </testlist>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -7,7 +7,7 @@
       <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:10:00 </option>
+      <option name="wallclock"> 00:05:00 </option>
     </options>
   </test>
   <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FKESSLER" >
@@ -17,7 +17,7 @@
       <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 00:05:00 </option>
     </options>
   </test>
   <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="QPC6" >
@@ -27,7 +27,7 @@
       <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
   <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="F2000climo" >
@@ -37,7 +37,7 @@
       <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
   <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupled-EW" testmods="earthworks/fullycoupled">
@@ -47,7 +47,7 @@
       <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 00:10:00 </option>
       <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi</option>
     </options>
   </test>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -43,7 +43,7 @@
       <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:10:00 </option>
+      <option name="wallclock"> 01:00:00 </option>
       <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi</option>
     </options>
   </test>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -36,7 +36,7 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
-  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupled-EW">
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
       <machine name="derecho" compiler="intel" category="ew-pr"/>
@@ -61,7 +61,7 @@
   </test>
 
   <!-- ew-rel Tests to run while creating a release -->
-  <test name="ERP_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupled-EW">
+  <test name="ERP_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
@@ -70,7 +70,7 @@
       <option name="wallclock"> 00:15:00 </option>
     </options>
   </test>
-  <test name="ERP_Vnuopc" grid="mpasa060_oQU060" compset="FullyCoupled-EW">
+  <test name="ERP_Vnuopc" grid="mpasa060_oQU060" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
@@ -79,7 +79,7 @@
       <option name="wallclock"> 00:30:00 </option>
     </options>
   </test>
-  <test name="ERP_Vnuopc" grid="mpasa030_oQU030" compset="FullyCoupled-EW">
+  <test name="ERP_Vnuopc" grid="mpasa030_oQU030" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
@@ -88,7 +88,7 @@
       <option name="wallclock"> 01:00:00 </option>
     </options>
   </test>
-  <test name="ERP_Vnuopc" grid="mpasa015z58_oQU015" compset="FullyCoupled-EW">
+  <test name="ERP_Vnuopc" grid="mpasa015z58_oQU015" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
@@ -97,7 +97,7 @@
       <option name="wallclock"> 01:00:00 </option>
     </options>
   </test>
-  <test name="ERP_Vnuopc" grid="mpasa120z58_oQU120" compset="FullyCoupled-EW">
+  <test name="ERP_Vnuopc" grid="mpasa120z58_oQU120" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>

--- a/cime_config/testmods_dirs/earthworks/fullycoupled/user_nl_mpaso
+++ b/cime_config/testmods_dirs/earthworks/fullycoupled/user_nl_mpaso
@@ -1,0 +1,2 @@
+
+config_cvmix_kpp_use_theory_wave = .true.

--- a/cime_config/testmods_dirs/earthworks/fullycoupled/user_nl_mpaso
+++ b/cime_config/testmods_dirs/earthworks/fullycoupled/user_nl_mpaso
@@ -1,2 +1,0 @@
-
-config_cvmix_kpp_use_theory_wave = .true.


### PR DESCRIPTION
Add definitions of compsets and tests so that typical EarthWorks cases can be run as CIME tests instead.

Testing instructions (in this thread): https://github.com/EarthWorksOrg/EarthWorks/pull/45#issuecomment-2118204061