### PR TITLE
Add EW compsets with MPAS-ocean/seaice

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -101,6 +101,19 @@
      <lname>1850_DATM%CRUv7_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM2%GRIS-EVOLVE_SWAV</lname>
   </compset>
 
+  <!-- EarthWorks compsets                  
+       MPAS-ocean and/or MPAS-seaice couplings -->
+
+  <compset>
+     <alias>F2000climoEW</alias>
+     <lname>2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+  </compset>
+
+  <compset>
+     <alias>B2000EW</alias>
+     <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
   <entries>
     <entry id="RUN_STARTDATE">
       <values>


### PR DESCRIPTION
This is an attempt to define new compsets that use MPAS-ocean and or MPAS-seaice instead of the default CESM components.

Specifically:
   F2000climoEW - analogous to F2000climo
     2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV
   B2000EW - analogous to B2000
     2000_CAM60_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV