### PR TITLE
Add 2 compsets that use cam_dev physics

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,7 +6,8 @@ local_path = ccs_config
 required = True
 
 [cam]
-tag = cam-ew2.1.004
+branch = ew-develop-rrtmgp2.2
+# tag = cam-ew2.1.004
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,8 +6,7 @@ local_path = ccs_config
 required = True
 
 [cam]
-branch = ew-develop-rrtmgp2.2
-# tag = cam-ew2.1.004
+tag = cam-ew2.1.005
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -107,7 +107,7 @@
   <!-- F2000climo, with MPASSI%PRES -->
   <compset>
      <alias>F2000climoEW</alias>
-     <lname>2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+     <lname>2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <!-- F2000dev, with MPASSI%PRES -->

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -110,6 +110,12 @@
      <lname>2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
   </compset>
 
+  <!-- F2000dev, with MPASSI%PRES -->
+  <compset>
+    <alias>F2000devEW</alias>
+    <lname>2000_CAM%DEV_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
   <compset>
       <alias>FullyCoupledEW</alias>
       <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_SROF_SGLC_SWAV</lname>
@@ -119,6 +125,12 @@
   <compset>
      <alias>CHAOS2000</alias>
      <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <!-- Use cam_dev / CAM7 physics instead -->
+  <compset>
+     <alias>CHAOS2000dev</alias>
+     <lname>2000_CAM%DEV_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <entries>


### PR DESCRIPTION
F2000devEW copies F2000dev from CAM, but uses the mpas-seaice prescribed mode instead of CICE. CHAOS2000dev uses the cam_dev physics instead of CAM6. These compsets should allow GPU runs of MPAS-A dycore, PUMAS, and RRTMPG.