### PR TITLE
Finalize before v2.2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,8 +6,7 @@ local_path = ccs_config
 required = True
 
 [cam]
-branch = update_v8mpasfiles_eworg
-# tag = cam-ew2.1.006
+tag = cam-ew2.1.006
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,7 +6,8 @@ local_path = ccs_config
 required = True
 
 [cam]
-tag = cam-ew2.1.005
+branch = update_v8mpasfiles_eworg
+# tag = cam-ew2.1.006
 protocol = git
 repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -28,7 +28,7 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
-  <test name="SMS_P128_Vnuopc" grid="mpasa120_mpasa120" compset="F2000climo" >
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="F2000climoEW" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
     </machines>
@@ -39,12 +39,21 @@
   <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+      <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi</option>
+    </options>
+  </test>
+  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="CHAOS2000dev">
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
       <machine name="derecho" compiler="intel" category="ew-pr"/>
       <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00:00 </option>
-      <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi</option>
+      <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi using cam_dev physics</option>
     </options>
   </test>
 

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -70,7 +70,7 @@
   </test>
 
   <!-- ew-rel Tests to run while creating a release -->
-  <test name="ERP_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupledEW">
+  <test name="ERS_P128_Vnuopc" grid="mpasa120_oQU120" compset="CHAOS2000dev">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
@@ -79,40 +79,40 @@
       <option name="wallclock"> 00:15:00 </option>
     </options>
   </test>
-  <test name="ERP_Vnuopc" grid="mpasa120z58_oQU120" compset="FullyCoupledEW">
+  <test name="ERS_P128_Vnuopc" grid="mpasa120z58_oQU120" compset="CHAOS2000dev">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 12:00:00 </option>
     </options>
   </test>
-  <test name="ERP_Vnuopc" grid="mpasa060_oQU060" compset="FullyCoupledEW">
+  <test name="ERS_P128_Vnuopc" grid="mpasa060_oQU060" compset="CHAOS2000dev">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:30:00 </option>
+      <option name="wallclock"> 12:00:00 </option>
     </options>
   </test>
-  <test name="ERP_Vnuopc" grid="mpasa030_oQU030" compset="FullyCoupledEW">
+  <test name="ERS_P5120_Vnuopc" grid="mpasa030_oQU030" compset="CHAOS2000dev">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 12:00:00 </option>
     </options>
   </test>
-  <test name="ERP_Vnuopc" grid="mpasa015z58_oQU015" compset="FullyCoupledEW">
+  <test name="ERS_P10240_Vnuopc" grid="mpasa015z58_oQU015" compset="CHAOS2000dev">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 12:00:00 </option>
     </options>
   </test>
 </testlist>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -70,6 +70,15 @@
       <option name="wallclock"> 00:15:00 </option>
     </options>
   </test>
+  <test name="ERP_Vnuopc" grid="mpasa120z58_oQU120" compset="FullyCoupledEW">
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
+      <machine name="derecho" compiler="intel" category="ew-rel"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
   <test name="ERP_Vnuopc" grid="mpasa060_oQU060" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
@@ -89,15 +98,6 @@
     </options>
   </test>
   <test name="ERP_Vnuopc" grid="mpasa015z58_oQU015" compset="FullyCoupledEW">
-    <machines>
-      <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
-      <machine name="derecho" compiler="intel" category="ew-rel"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00:00 </option>
-    </options>
-  </test>
-  <test name="ERP_Vnuopc" grid="mpasa120z58_oQU120" compset="FullyCoupledEW">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>


### PR DESCRIPTION
These changes bring in a fix to namelist_defaults_cam.xml and aligns the testlist_earthworks.xml with the CPU tests described in the v2.2 (draft) release notes.

The changes to the `ew-rel` category make it so that the most complicated compset (CHAOS2000dev) is exercised at every supported EW resolution using an "exact restart" test.