### PR TITLE
Add config_archive.xml to MPAS-O and MPAS-SI

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -95,16 +95,20 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-tag = mpaso-ew2.2.000
+branch = mpaso_add_configarchive
+# tag = mpaso-ew2.2.000
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
+repo_url = https://github.com/gdicker1/mpas-ocean.git
+# repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-tag = mpassi-ew2.2.000
+branch = mpassi_add_configarchive
+# tag = mpassi-ew2.2.000
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
+repo_url = https://github.com/gdicker1/mpas-seaice.git
+# repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -95,20 +95,16 @@ externals = Externals_CLM.cfg
 required = True
 
 [mpas-ocean]
-branch = mpaso_add_configarchive
-# tag = mpaso-ew2.2.000
+tag = mpaso-ew2.2.001
 protocol = git
-repo_url = https://github.com/gdicker1/mpas-ocean.git
-# repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
+repo_url = https://github.com/EarthWorksOrg/mpas-ocean.git
 local_path = components/mpas-ocean
 required = True
 
 [mpas-seaice]
-branch = mpassi_add_configarchive
-# tag = mpassi-ew2.2.000
+tag = mpassi-ew2.2.001
 protocol = git
-repo_url = https://github.com/gdicker1/mpas-seaice.git
-# repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
+repo_url = https://github.com/EarthWorksOrg/mpas-seaice.git
 local_path = components/mpas-seaice
 required = True
 


### PR DESCRIPTION
These changes allow the short-term and long-term archiver scripts to grab the correct restart and history files for these components. This moves the `create_test` framework closer to working and allowing EarthWorks to generate and compare against baselines.