### PR TITLE
Update ccs_configs to fix link step failures for high pcols builds

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,7 @@
 [ccs_config]
-branch = fix/mcmodel_highpcols_linkstep
-# tag = ccs_config-ew2.2.000
+tag = ccs_config-ew2.2.001
 protocol = git
-repo_url = https://github.com/gdicker1/ccs_config_cesm.git
-# repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,9 @@
 [ccs_config]
-tag = ccs_config-ew2.2.000
+branch = fix/mcmodel_highpcols_linkstep
+# tag = ccs_config-ew2.2.000
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+repo_url = https://github.com/gdicker1/ccs_config_cesm.git
+# repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 


### PR DESCRIPTION
Bring in changes to EarthWorksOrg/ccs_config_cesm to address link step failures when building CAM with `pcols` > 2048.

Fix #56 