### PR TITLE
Bug Fix after v2.3 Release [develop]

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,9 @@
 [ccs_config]
-tag = ccs_config-ew2.3.000
+branch = bugfix/remove_mergetext_mcmodel
+# tag = ccs_config-ew2.3.000
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+repo_url = https://github.com/gdicker1/ccs_config_cesm.git
+# repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,7 @@
 [ccs_config]
-branch = bugfix/remove_mergetext_mcmodel
-# tag = ccs_config-ew2.3.000
+tag = ccs_config-ew2.3.001
 protocol = git
-repo_url = https://github.com/gdicker1/ccs_config_cesm.git
-# repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 


### PR DESCRIPTION
Duplicate #64 for the develop branch

This is duplicated due to the practice of using "release-{repo}-ew{X}.{Y}" tags in Externals.cfg on the EarthWorks main branch and "{repo}-ew{X}.{Y}.{Z}" in the develop branch. The reason for this PR will become more apparent once the Sub-PR is merged and tagged.