### PR TITLE
Update externals based on ESCOMP/CESM tag 'cesm2_3_beta17'

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -96,7 +96,7 @@ required = True
 
 [clm]
 # tag = ctsm-ew2.3.000
-branch = update/cesm2_3_beta17/ctsm5.2.005
+branch = update/cesm2_3_beta17/ctsm5.2.005-2
 protocol = git
 # repo_url = https://github.com/EarthWorksOrg/CTSM
 repo_url = https://github.com/gdicker1/CTSM

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,18 +1,14 @@
 [ccs_config]
-# tag = ccs_config-ew2.3.001
-branch = update/cesm2_3_beta17/ccs_config_cesm0.0.106
+tag = ccs_config-ew2.3.002
 protocol = git
-# repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
-repo_url = https://github.com/gdicker1/ccs_config_cesm.git
+repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cam]
-# tag = cam-ew2.3.000
-branch = update/cesm2_3_beta17/cam6_3_160
+tag = cam-ew2.3.001
 protocol = git
-#repo_url = https://github.com/EarthWorksOrg/CAM
-repo_url = https://github.com/gdicker1/CAM
+repo_url = https://github.com/EarthWorksOrg/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True
@@ -33,11 +29,9 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-# tag = cmeps-ew2.3.000
-branch = update/cesm2_3_beta17/cmeps0.14.60
+tag = cmeps-ew2.3.001
 protocol = git
-# repo_url = https://github.com/EarthWorksOrg/CMEPS.git
-repo_url = https://github.com/gdicker1/CMEPS.git
+repo_url = https://github.com/EarthWorksOrg/CMEPS.git
 local_path = components/cmeps
 required = True
 
@@ -78,11 +72,9 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-# tag = cime-ew2.3.000
-branch = update/cesm2_3_beta17/cime6.0.238_httpsbranch01
+tag = cime-ew2.3.001
 protocol = git
-# repo_url = https://github.com/EarthWorksOrg/cime
-repo_url = https://github.com/gdicker1/cime
+repo_url = https://github.com/EarthWorksOrg/cime
 local_path = cime
 required = True
 
@@ -95,11 +87,9 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-# tag = ctsm-ew2.3.000
-branch = update/cesm2_3_beta17/ctsm5.2.005-2
+tag = ctsm-ew2.3.001
 protocol = git
-# repo_url = https://github.com/EarthWorksOrg/CTSM
-repo_url = https://github.com/gdicker1/CTSM
+repo_url = https://github.com/EarthWorksOrg/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,14 +1,18 @@
 [ccs_config]
-tag = ccs_config-ew2.3.001
+# tag = ccs_config-ew2.3.001
+branch = update/cesm2_3_beta17/ccs_config_cesm0.0.106
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+# repo_url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+repo_url = https://github.com/gdicker1/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cam]
-tag = cam-ew2.3.000
+# tag = cam-ew2.3.000
+branch = update/cesm2_3_beta17/cam6_3_160
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/CAM
+#repo_url = https://github.com/EarthWorksOrg/CAM
+repo_url = https://github.com/gdicker1/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True
@@ -21,7 +25,7 @@ local_path = components/cice5
 required = True
 
 [cice6]
-tag = cesm_cice6_4_1_10
+tag = cesm_cice6_5_0_7
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE
 local_path = components/cice
@@ -29,14 +33,16 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-tag = cmeps-ew2.3.000
+# tag = cmeps-ew2.3.000
+branch = update/cesm2_3_beta17/cmeps0.14.60
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/CMEPS.git
+# repo_url = https://github.com/EarthWorksOrg/CMEPS.git
+repo_url = https://github.com/gdicker1/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps1.0.26
+tag = cdeps1.0.33
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -44,7 +50,7 @@ externals = Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl77.0.7
+tag = cpl77.0.8
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
@@ -72,14 +78,16 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime-ew2.3.000
+# tag = cime-ew2.3.000
+branch = update/cesm2_3_beta17/cime6.0.238_httpsbranch01
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/cime
+# repo_url = https://github.com/EarthWorksOrg/cime
+repo_url = https://github.com/gdicker1/cime
 local_path = cime
 required = True
 
 [cism]
-tag = cismwrap_2_1_96
+tag = cismwrap_2_1_100
 protocol = git
 repo_url = https://github.com/ESCOMP/CISM-wrapper
 local_path = components/cism
@@ -87,9 +95,11 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm-ew2.3.000
+# tag = ctsm-ew2.3.000
+branch = update/cesm2_3_beta17/ctsm5.2.005
 protocol = git
-repo_url = https://github.com/EarthWorksOrg/CTSM
+# repo_url = https://github.com/EarthWorksOrg/CTSM
+repo_url = https://github.com/gdicker1/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True
@@ -116,7 +126,7 @@ local_path = components/mpas-framework
 required = True
 
 [mosart]
-tag = mosart1_0_48
+tag = mosart1_0_49
 protocol = git
 repo_url = https://github.com/ESCOMP/MOSART
 local_path = components/mosart

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -44,6 +44,16 @@
   </compset>
 
   <compset>
+    <alias>BLT1850_v0c</alias>
+    <lname>1850_CAM%DEV%LT%GHGMAM4_CLM51%BGC-CROP_CICE_MOM6_MOSART_CISM2%GRIS-NOEVOLVE_WW3</lname>
+  </compset>
+
+  <compset>
+    <alias>BLTHIST_v0c</alias>
+    <lname>HIST_CAM%DEV%LT%GHGMAM4_CLM51%BGC-CROP_CICE_MOM6_MOSART_CISM2%GRIS-NOEVOLVE_WW3</lname>
+  </compset>
+
+  <compset>
     <alias>BW1850</alias>
     <lname>1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%GRIS-NOEVOLVE_WW3</lname>
   </compset>
@@ -147,8 +157,3 @@
   </entries>
 
 </compsets>
-
-
-
-
-

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -40,23 +40,143 @@
     </mach>
   </grid>
 
-  <grid name="any">
-    <mach name="cori-knl">
-      <pes pesize="any" compset="any">
-	<comment>use 2 hyperthreads per core</comment>
+  <grid name="a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v2">
+    <mach name="derecho">
+      <pes pesize="XL" compset="CAM.*%LT.*MOM6">
+	<comment>20 ypd/ 7100 pe-hrs/simyr expected</comment>
+	<ntasks>
+	  <ntasks_atm>5400</ntasks_atm>
+	  <ntasks_lnd>939</ntasks_lnd>
+	  <ntasks_rof>64</ntasks_rof>
+	  <ntasks_ice>4397</ntasks_ice>
+	  <ntasks_ocn>488</ntasks_ocn>
+	  <ntasks_glc>64</ntasks_glc>
+	  <ntasks_wav>64</ntasks_wav>
+	  <ntasks_cpl>5400</ntasks_cpl>
+	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>1003</rootpe_ice>
+	  <rootpe_ocn>5400</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="L" compset="CAM.*%LT.*MOM6">
+	<comment>13.9 ypd/ 5300 pe-hrs/simyr expected</comment>
+	<ntasks>
+	  <ntasks_atm>2700</ntasks_atm>
+	  <ntasks_lnd>896</ntasks_lnd>
+	  <ntasks_rof>32</ntasks_rof>
+	  <ntasks_ice>1772</ntasks_ice>
+	  <ntasks_ocn>372</ntasks_ocn>
+	  <ntasks_glc>32</ntasks_glc>
+	  <ntasks_wav>32</ntasks_wav>
+	  <ntasks_cpl>2700</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>896</rootpe_rof>
+	  <rootpe_ice>928</rootpe_ice>
+	  <rootpe_ocn>2700</rootpe_ocn>
+	  <rootpe_glc>896</rootpe_glc>
+	  <rootpe_wav>896</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="M" compset="CAM.*%LT.*MOM6">
+	<comment>10 ypd/ 5100 pe-hrs/simyr expected</comment>
+	<ntasks>
+	  <ntasks_atm>1920</ntasks_atm>
+	  <ntasks_lnd>640</ntasks_lnd>
+	  <ntasks_rof>512</ntasks_rof>
+	  <ntasks_ice>1152</ntasks_ice>
+	  <ntasks_ocn>384</ntasks_ocn>
+	  <ntasks_glc>64</ntasks_glc>
+	  <ntasks_wav>64</ntasks_wav>
+	  <ntasks_cpl>1920</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>704</rootpe_ice>
+	  <rootpe_ocn>1920</rootpe_ocn>
+	  <rootpe_glc>1856</rootpe_glc>
+	  <rootpe_wav>1792</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="S" compset="CAM.*%LT.*MOM6">
+	<comment>2.9 ypd/ 4185 pe-hrs/simyr expected</comment>
+	<ntasks>
+	  <ntasks_atm>448</ntasks_atm>
+	  <ntasks_lnd>208</ntasks_lnd>
+	  <ntasks_rof>16</ntasks_rof>
+	  <ntasks_ice>224</ntasks_ice>
+	  <ntasks_ocn>64</ntasks_ocn>
+	  <ntasks_glc>16</ntasks_glc>
+	  <ntasks_wav>16</ntasks_wav>
+	  <ntasks_cpl>448</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>16</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>224</rootpe_ice>
+	  <rootpe_ocn>448</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
       </pes>
     </mach>
   </grid>
+
   <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
     <mach name="any">
       <pes pesize="any" compset="any">
@@ -94,89 +214,19 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
-    <mach name="cori-knl">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-4</ntasks_atm>
-	  <ntasks_lnd>-2</ntasks_lnd>
-	  <ntasks_rof>-2</ntasks_rof>
-	  <ntasks_ice>-2</ntasks_ice>
-	  <ntasks_ocn>-2</ntasks_ocn>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_cpl>-4</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-2</rootpe_ice>
-	  <rootpe_ocn>-4</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1" >
-    <mach name="cheyenne">
+    <mach name="derecho">
       <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+">
-	<comment>about 12ypd expected</comment>
+	<comment></comment>
 	<ntasks>
-	  <ntasks_atm>288</ntasks_atm>
-	  <ntasks_lnd>144</ntasks_lnd>
-	  <ntasks_rof>40</ntasks_rof>
-	  <ntasks_ice>108</ntasks_ice>
-	  <ntasks_ocn>288</ntasks_ocn>
-	  <ntasks_glc>36</ntasks_glc>
-	  <ntasks_wav>36</ntasks_wav>
-	  <ntasks_cpl>288</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>144</rootpe_ice>
-	  <rootpe_ocn>288</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>252</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="M3" compset="CAM.+CLM.+CICE.+POP.+">
-	<comment>For multi-instance tests</comment>
-	<ntasks>
-	  <ntasks_atm>-36</ntasks_atm>
-	  <ntasks_lnd>-12</ntasks_lnd>
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-3</ntasks_lnd>
 	  <ntasks_rof>-3</ntasks_rof>
-	  <ntasks_ice>-9</ntasks_ice>
-	  <ntasks_ocn>-36</ntasks_ocn>
-	  <ntasks_glc>-3</ntasks_glc>
-	  <ntasks_wav>-3</ntasks_wav>
-	  <ntasks_cpl>-36</ntasks_cpl>
+	  <ntasks_ice>-5</ntasks_ice>
+	  <ntasks_ocn>-8</ntasks_ocn>
+	  <ntasks_glc>64</ntasks_glc>
+	  <ntasks_wav>64</ntasks_wav>
+	  <ntasks_cpl>-8</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
@@ -192,47 +242,10 @@
 	  <rootpe_atm>0</rootpe_atm>
 	  <rootpe_lnd>0</rootpe_lnd>
 	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>144</rootpe_ice>
-	  <rootpe_ocn>288</rootpe_ocn>
+	  <rootpe_ice>-3</rootpe_ice>
+	  <rootpe_ocn>-8</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>252</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
-    <mach name="cori-haswell">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm>
-	  <ntasks_lnd>-9</ntasks_lnd>
-	  <ntasks_rof>-9</ntasks_rof>
-	  <ntasks_ice>-7</ntasks_ice>
-	  <ntasks_ocn>-1</ntasks_ocn>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_cpl>-16</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-9</rootpe_ice>
-	  <rootpe_ocn>-16</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_wav>64</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
@@ -349,77 +362,40 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30np4.+l%ne30np4.+oi%gx1" >
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>2600</ntasks_atm>
-	  <ntasks_lnd>144</ntasks_lnd>
-	  <ntasks_rof>144</ntasks_rof>
-	  <ntasks_ice>2456</ntasks_ice>
-	  <ntasks_ocn>192</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>2600</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_ice>144</rootpe_ice>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ocn>2600</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne30np4.+l%ne30np4.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>960</ntasks_atm>
-	  <ntasks_lnd>48</ntasks_lnd>
-	  <ntasks_rof>48</ntasks_rof>
-	  <ntasks_ice>912</ntasks_ice>
-	  <ntasks_ocn>48</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>960</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>48</rootpe_ice>
-	  <rootpe_ocn>960</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
+  <grid name="a%ne30np4.+l%ne30np4.+oi%tx2_3v2" >
+    <mach name="cheyenne">
+      <pes pesize="any" compset="CAM.*%LT.+CLM.+CICE.+MOM6.+WW3">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>1800</ntasks_atm>
+          <ntasks_lnd>720</ntasks_lnd>
+          <ntasks_rof>720</ntasks_rof>
+          <ntasks_ice>1080</ntasks_ice>
+          <ntasks_ocn>324</ntasks_ocn>
+          <ntasks_glc>36</ntasks_glc>
+          <ntasks_wav>36</ntasks_wav>
+          <ntasks_cpl>1800</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>720</rootpe_ice>
+          <rootpe_ocn>1800</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>1</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
       </pes>
     </mach>
   </grid>
@@ -461,43 +437,6 @@
     </mach>
   </grid>
   <grid name="a%ne120np4.+l%ne120np4.+oi%tx0.1v2">
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>12384</ntasks_atm>
-	  <ntasks_lnd>96</ntasks_lnd>
-	  <ntasks_rof>96</ntasks_rof>
-	  <ntasks_ice>12288</ntasks_ice>
-	  <ntasks_ocn>4000</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>12384</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	  <nthrds_glc>8</nthrds_glc>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>96</rootpe_ice>
-	  <rootpe_ocn>12384</rootpe_ocn>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	  <rootpe_glc>0</rootpe_glc>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne120np4.+l%ne120np4.+oi%tx0.1v2">
     <mach name="stampede|titan" >
       <pes pesize="any" compset="any">
 	<comment>none</comment>
@@ -527,43 +466,6 @@
 	  <rootpe_rof>0</rootpe_rof>
 	  <rootpe_ice>0</rootpe_ice>
 	  <rootpe_ocn>1440</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne240np4.+l%ne240.+oi%gx1"  >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>9600</ntasks_atm>
-	  <ntasks_lnd>8640</ntasks_lnd>
-	  <ntasks_rof>600</ntasks_rof>
-	  <ntasks_ice>960</ntasks_ice>
-	  <ntasks_ocn>960</ntasks_ocn>
-	  <ntasks_glc>960</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>960</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>8640</rootpe_ice>
-	  <rootpe_ocn>9600</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
@@ -602,43 +504,6 @@
 	  <rootpe_cpl>0</rootpe_cpl>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-64</ntasks_atm>
-	  <ntasks_lnd>-16</ntasks_lnd>
-	  <ntasks_rof>-16</ntasks_rof>
-	  <ntasks_ice>-48</ntasks_ice>
-	  <ntasks_cpl>-64</ntasks_cpl>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_ocn>-16</ntasks_ocn>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_cpl>8</nthrds_cpl>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_ocn>8</nthrds_ocn>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-16</rootpe_ice>
-	  <rootpe_cpl>0</rootpe_cpl>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_ocn>-64</rootpe_ocn>
 	</rootpe>
       </pes>
     </mach>
@@ -863,117 +728,6 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>96</ntasks_atm>
-	  <ntasks_lnd>96</ntasks_lnd>
-	  <ntasks_rof>96</ntasks_rof>
-	  <ntasks_ice>96</ntasks_ice>
-	  <ntasks_ocn>96</ntasks_ocn>
-	  <ntasks_glc>96</ntasks_glc>
-	  <ntasks_wav>96</ntasks_wav>
-	  <ntasks_cpl>96</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5_l%1.9x2.5_oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="CAM.+WISO.+CLM.+CICE.+POP">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>640</ntasks_atm>
-	  <ntasks_lnd>96</ntasks_lnd>
-	  <ntasks_rof>96</ntasks_rof>
-	  <ntasks_ice>544</ntasks_ice>
-	  <ntasks_ocn>96</ntasks_ocn>
-	  <ntasks_glc>180</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>640</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>544</rootpe_lnd>
-	  <rootpe_rof>544</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>640</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="CAM.+CLM.+CICE_DOCN%SOM">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>96</ntasks_atm>
-	  <ntasks_lnd>96</ntasks_lnd>
-	  <ntasks_rof>96</ntasks_rof>
-	  <ntasks_ice>96</ntasks_ice>
-	  <ntasks_ocn>96</ntasks_ocn>
-	  <ntasks_glc>96</ntasks_glc>
-	  <ntasks_wav>96</ntasks_wav>
-	  <ntasks_cpl>96</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name='any'>
       <pes pesize="any" compset="any">
@@ -985,7 +739,7 @@
 	  <ntasks_ice>-4</ntasks_ice>
 	  <ntasks_ocn>-1</ntasks_ocn>
 	  <ntasks_glc>-8</ntasks_glc>
-	  <ntasks_wav>-8</ntasks_wav>
+	  <ntasks_wav>-2</ntasks_wav>
 	  <ntasks_cpl>-8</ntasks_cpl>
 	</ntasks>
 	<nthrds>
@@ -997,43 +751,6 @@
 	  <nthrds_glc>1</nthrds_glc>
 	  <nthrds_wav>1</nthrds_wav>
 	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-4</rootpe_ice>
-	  <rootpe_ocn>-8</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name='cori-knl'>
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm>
-	  <ntasks_lnd>-4</ntasks_lnd>
-	  <ntasks_rof>-4</ntasks_rof>
-	  <ntasks_ice>-4</ntasks_ice>
-	  <ntasks_ocn>-1</ntasks_ocn>
-	  <ntasks_glc>-8</ntasks_glc>
-	  <ntasks_wav>-8</ntasks_wav>
-	  <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1361,153 +1078,6 @@
 	</rootpe>
       </pes>
     </mach>
-    <mach name="edison">
-      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+WW3">
-	<comment>about 17ypd expected</comment>
-	<ntasks>
-	  <ntasks_atm>-50</ntasks_atm>
-	  <ntasks_lnd>-30</ntasks_lnd>
-	  <ntasks_rof>-30</ntasks_rof>
-	  <ntasks_ice>-18</ntasks_ice>
-	  <ntasks_ocn>-20</ntasks_ocn>
-	  <ntasks_glc>-30</ntasks_glc>
-	  <ntasks_wav>-2</ntasks_wav>
-	  <ntasks_cpl>-50</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-30</rootpe_ice>
-	  <rootpe_ocn>-50</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>-48</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name='cori-haswell'>
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm>
-	  <ntasks_lnd>-9</ntasks_lnd>
-	  <ntasks_rof>-9</ntasks_rof>
-	  <ntasks_ice>-7</ntasks_ice>
-	  <ntasks_ocn>-1</ntasks_ocn>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_cpl>-16</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-9</rootpe_ice>
-	  <rootpe_ocn>-16</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <!-- NTASKS_ATM is maxed out NTASKS_OCN overly large to fit 256 nodes on mira -->
-    <mach name='mira'>
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-208</ntasks_atm>
-	  <ntasks_lnd>-32</ntasks_lnd>
-	  <ntasks_rof>-32</ntasks_rof>
-	  <ntasks_ice>-80</ntasks_ice>
-	  <ntasks_ocn>-48</ntasks_ocn>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_cpl>-208</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>-32</rootpe_rof>
-	  <rootpe_ice>-64</rootpe_ice>
-	  <rootpe_ocn>-208</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>960</ntasks_atm>
-	  <ntasks_lnd>48</ntasks_lnd>
-	  <ntasks_rof>48</ntasks_rof>
-	  <ntasks_ice>912</ntasks_ice>
-	  <ntasks_ocn>48</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>960</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>48</rootpe_ice>
-	  <rootpe_ocn>960</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="stampede|titan" >
@@ -1539,81 +1109,6 @@
 	  <rootpe_rof>0</rootpe_rof>
 	  <rootpe_ice>64</rootpe_ice>
 	  <rootpe_ocn>384</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name="laramie">
-      <pes pesize="M" compset="CAM.+CLM.+CICE.+POP.+">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm>
-	  <ntasks_lnd>-6</ntasks_lnd>
-	  <ntasks_rof>-6</ntasks_rof>
-	  <ntasks_ice>-2</ntasks_ice>
-	  <ntasks_ocn>-2</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>-4</ntasks_wav>
-	  <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-6</rootpe_ice>
-	  <rootpe_ocn>-8</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="CAM.+CLM.+CICE.+DOCN%SOM">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>192</ntasks_atm>
-	  <ntasks_lnd>192</ntasks_lnd>
-	  <ntasks_rof>192</ntasks_rof>
-	  <ntasks_ice>192</ntasks_ice>
-	  <ntasks_ocn>192</ntasks_ocn>
-	  <ntasks_glc>192</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>192</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
@@ -1658,43 +1153,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne120.+l%ne120.+oi%gx1" >
-    <mach name="bluewaters">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>3200</ntasks_atm>
-	  <ntasks_lnd>1600</ntasks_lnd>
-	  <ntasks_rof>1600</ntasks_rof>
-	  <ntasks_ice>1600</ntasks_ice>
-	  <ntasks_ocn>32</ntasks_ocn>
-	  <ntasks_glc>3200</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>3200</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>1600</rootpe_ice>
-	  <rootpe_ocn>3200</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
+
 
   <!-- J compset (all active except data atmosphere)
        Laid out as follows:

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -2,7 +2,7 @@
 <testlist version="2.0">
   <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00:00 </option>
@@ -10,7 +10,7 @@
   </test>
   <test name="SMS_Ld2" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
+      <machine name="derecho" compiler="intel" category="aux_cime_baselines"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -18,7 +18,15 @@
   </test>
   <test name="SMS_Ld2" grid="ne30pg3_t061" compset="B1850MOM" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="prealpha"/>
+      <machine name="derecho" compiler="gnu" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:30:00 </option>
+    </options>
+  </test>
+  <test name="SMS_Ld2" grid="ne30pg3_t232" compset="BLT1850_v0c" testmods="allactive/defaultio">
+    <machines>
+      <machine name="derecho" compiler="gnu" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -26,7 +34,7 @@
   </test>
   <test name="SMS_Ld2" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="aux_cime_baselines"/>
+      <machine name="derecho" compiler="gnu" category="aux_cime_baselines"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -34,7 +42,7 @@
   </test>
   <test name="MCC" grid="f19_g17" compset="B1850" testmods="allactive/defaultiomi">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 02:00:00 </option>
@@ -42,15 +50,7 @@
   </test>
   <test name="ERS_D" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 06:00:00 </option>
-    </options>
-  </test>
-  <test name="ERS_D_Vmct" grid="f09_g17" compset="1850_CAM60_CLM50%BGC-CROP_CICE5_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3_BGC%BDRD" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 06:00:00 </option>
@@ -58,15 +58,7 @@
   </test>
   <test name="IRT_Ld7" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30:00 </option>
-    </options>
-  </test>
-  <test name="IRT_Ld7_Vmct" grid="f09_g17" compset="HIST_CAM60_CLM50%BGC-CROP_CICE5_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3_BGC%BDRD" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -74,8 +66,8 @@
   </test>
   <test name="SMS_Ld1" grid="f09_g17" compset="BW1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="bwaccm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00:00 </option>
@@ -83,8 +75,8 @@
   </test>
   <test name="SMS_Ld5" grid="f19_g17" compset="BWma1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="bwaccm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00:00 </option>
@@ -92,8 +84,8 @@
   </test>
   <test name="SMS_Ld1" grid="f09_g17" compset="BWma1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="bwaccm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00:00 </option>
@@ -101,7 +93,7 @@
   </test>
   <test name="IRT_Ld7" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00:00 </option>
@@ -109,7 +101,7 @@
   </test>
   <test name="ERS_Ld5" grid="f19_g17" compset="E1850TEST" testmods="cice/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -117,7 +109,7 @@
   </test>
   <test name="ERS_Ld7" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne"   compiler="intel" category="prealpha"/>
+      <machine name="derecho"   compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -125,8 +117,8 @@
   </test>
   <test name="IRT_C3_Ld7" grid="f19_g17" compset="BHIST" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 02:00:00 </option>
@@ -134,8 +126,8 @@
   </test>
   <test name="MCC_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 01:30:00 </option>
@@ -143,17 +135,8 @@
   </test>
   <test name="PET_PM" grid="f19_g17" compset="B1850" testmods="allactive/defaultiomi">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:30:00 </option>
-    </options>
-  </test>
-  <test name="PET_PM_Vmct" grid="f19_g17" compset="1850_CAM60_CLM50%BGC-CROP_CICE5_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3_BGC%BDRD" testmods="allactive/defaultiomi">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="gnu" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:30:00 </option>
@@ -161,8 +144,8 @@
   </test>
   <test name="PFS" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
@@ -170,7 +153,7 @@
   </test>
   <test name="PFS" grid="f09_g17" compset="B1850" testmods="allactive/maxthroughputb">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_perf"/>
+      <machine name="derecho" compiler="intel" category="aux_perf"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40:00 </option>
@@ -178,12 +161,12 @@
   </test>
   <test compset="FW1850" grid="f09_f09_mg17" name="PFS" testmods="allactive/maxthroughputfw">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_perf"/>
+      <machine name="derecho" compiler="intel" category="aux_perf"/>
     </machines>
   </test>
   <test name="SMS_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -191,7 +174,7 @@
   </test>
   <test name="SMS_Ld5" grid="f09_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -199,7 +182,7 @@
   </test>
   <test name="SMS_Ld5" grid="f09_g17_gl4" compset="J1850G" testmods="allactive/cism/test_coupling">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
+      <machine name="derecho" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30:00 </option>
@@ -207,7 +190,7 @@
   </test>
   <test name="SMS_Ld7" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock">  00:30:00 </option>

--- a/cime_config/testmods_dirs/allactive/defaultiomi/shell_commands
+++ b/cime_config/testmods_dirs/allactive/defaultiomi/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange NTASKS_OCN=144
+./xmlchange NTASKS_OCN=-2


### PR DESCRIPTION
This is the first of a series of PRs that will update EarthWorks to more closely match the current development of ESCOMP/CESM.

This PR combines changes to use externals based on those used in the cesm2_3_beta17 tag and to update the cime_config folder with CESM changes. 