### PR TITLE
Update Derecho software stack, get nvhpc/24.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,8 +28,8 @@
 
 [submodule "ccs_config"]
         path = ccs_config
-        url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
-        fxDONOTUSEurl = https://github.com/gdicker1/ccs_config_cesm.git
+        url = https://github.com/gdicker1/ccs_config_cesm.git
+        fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
         fxtag = derecho_updates_2024Oct17
         fxrequired = ToplevelRequired
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -29,8 +29,8 @@
 [submodule "ccs_config"]
         path = ccs_config
         url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
-        fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        fxtag = ccs_config-ew2.3.004
+        fxDONOTUSEurl = https://github.com/gdicker1/ccs_config_cesm.git
+        fxtag = derecho_updates_2024Oct17
         fxrequired = ToplevelRequired
 
 [submodule "cime"]

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -2,6 +2,37 @@
 <testlist version="2.0">
 
   <!-- ew-pr Tests to run for the EW PR process -->
+  <test name="ERP_Ln9_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:05:00 </option>
+      <option name="comment">Atmosphere-only test with Held Suarez simple physics. Exact restart tests that uses half the PEs when restarted</option>
+    </options>
+  </test>
+  <test name="ERP_Ln9_P128_Vnuopc" grid="mpasa120_oQU120" compset="F2000climoEW" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+      <option name="comment">Analogue to F2000climo in ESCOMP/CAM, but with MPASSI%PRES instead of CICE. Exact restart tests that uses half the PEs when restarted</option>
+    </options>
+  </test>
+  <test name="ERP_Ln9_P256_Vnuopc" grid="mpasa120_oQU120" compset="CHAOS2000dev" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+      <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi using cam_dev physics. Exact restart tests that uses half the PEs when restarted</option>
+    </options>
+  </test>
   <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>


### PR DESCRIPTION
Use newer modules for software on Derecho.

NOTE: only gcc+cray-mpich in this update has debug versions of both parallelio and esmf. Other combinations will use the default modules when using DEBUG=true.

Removes intel-classic as well.

This PR is intended to merge after #76. See the EarthWorksOrg/ccs_config_cesm [PR#29](https://github.com/EarthWorksOrg/ccs_config_cesm/pull/29) for more information.