### PR TITLE
Upgrade Derecho nvhpc software stack to 24.9, add restart tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,9 @@
 
 [submodule "ccs_config"]
         path = ccs_config
-        url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+        url = https://github.com/gdicker1/ccs_config_cesm.git
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        fxtag = ccs_config-ew2.3.005
+        fxtag = derecho_nvhpc249_2024Oct25
         fxrequired = ToplevelRequired
 
 [submodule "cime"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,9 @@
 
 [submodule "ccs_config"]
         path = ccs_config
-        url = https://github.com/gdicker1/ccs_config_cesm.git
+        url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        fxtag = derecho_nvhpc249_2024Oct25
+        fxtag = ccs_config-ew2.3.006
         fxrequired = ToplevelRequired
 
 [submodule "cime"]

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -40,7 +40,7 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
-  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="F2000climoEW" >
+  <test name="SMS_P256_Vnuopc" grid="mpasa120_oQU120" compset="F2000climoEW" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
     </machines>
@@ -48,7 +48,7 @@
       <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
-  <test name="SMS_P128_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupledEW" >
+  <test name="SMS_P256_Vnuopc" grid="mpasa120_oQU120" compset="FullyCoupledEW" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
     </machines>
@@ -61,6 +61,14 @@
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
       <machine name="derecho" compiler="intel" category="ew-pr"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+      <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi using cam_dev physics</option>
+    </options>
+  </test>
+  <test name="SMS_P256_Vnuopc" grid="mpasa120_oQU120" compset="CHAOS2000dev" >
+    <machines>
       <machine name="derecho" compiler="gnu" category="ew-pr"/>
     </machines>
     <options>
@@ -82,7 +90,7 @@
   </test>
 
   <!-- ew-rel Tests to run while creating a release -->
-  <test name="ERS_P128_Vnuopc" grid="mpasa120_oQU120" compset="CHAOS2000dev">
+  <test name="ERS_P256_Vnuopc" grid="mpasa120_oQU120" compset="CHAOS2000dev">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
@@ -91,7 +99,7 @@
       <option name="wallclock"> 00:15:00 </option>
     </options>
   </test>
-  <test name="ERS_P128_Vnuopc" grid="mpasa120z58_oQU120" compset="CHAOS2000dev">
+  <test name="ERS_P256_Vnuopc" grid="mpasa120z58_oQU120" compset="CHAOS2000dev">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>
@@ -100,7 +108,7 @@
       <option name="wallclock"> 12:00:00 </option>
     </options>
   </test>
-  <test name="ERS_P128_Vnuopc" grid="mpasa060_oQU060" compset="CHAOS2000dev">
+  <test name="ERS_P256_Vnuopc" grid="mpasa060_oQU060" compset="CHAOS2000dev">
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-rel"/>
       <machine name="derecho" compiler="intel" category="ew-rel"/>

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <!-- ew-pr to run for the EW PR process -->
+  <!-- ew-pr Tests to run for the EW PR process -->
   <test name="ERP_Ln9_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94" testmods="cam/outfrq9s_mpasa120" >
     <machines>
-      <machine name="derecho" compiler="nvhpc" category="ew-pr-restart"/>
-      <machine name="derecho" compiler="intel" category="ew-pr-restart"/>
-      <machine name="derecho" compiler="gnu"   category="ew-pr-restart"/>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu"   category="ew-pr"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -15,23 +15,13 @@
   </test>
   <test name="ERP_Ln9_P256_Vnuopc" grid="mpasa120_oQU120" compset="CHAOS2000dev" testmods="cam/outfrq9s_mpasa120" >
     <machines>
-      <machine name="derecho" compiler="nvhpc" category="ew-pr-restart"/>
-      <machine name="derecho" compiler="intel" category="ew-pr-restart"/>
-      <machine name="derecho" compiler="gnu"   category="ew-pr-restart"/>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
+      <machine name="derecho" compiler="intel" category="ew-pr"/>
+      <machine name="derecho" compiler="gnu"   category="ew-pr"/>
     </machines>
     <options>
       <option name="wallclock"> 02:00:00 </option>
       <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi using cam_dev physics. Exact restart tests that uses half the PEs when restarted</option>
-    </options>
-  </test>
-  <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94" >
-    <machines>
-      <machine name="derecho" compiler="nvhpc" category="ew-pr"/>
-      <machine name="derecho" compiler="intel" category="ew-pr"/>
-      <machine name="derecho" compiler="gnu" category="ew-pr"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:05:00 </option>
     </options>
   </test>
   <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FKESSLER" >

--- a/cime_config/testlist_earthworks.xml
+++ b/cime_config/testlist_earthworks.xml
@@ -1,7 +1,29 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <!-- ew-pr Tests to run for the EW PR process -->
+  <!-- ew-pr to run for the EW PR process -->
+  <test name="ERP_Ln9_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94" testmods="cam/outfrq9s_mpasa120" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr-restart"/>
+      <machine name="derecho" compiler="intel" category="ew-pr-restart"/>
+      <machine name="derecho" compiler="gnu"   category="ew-pr-restart"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+      <option name="comment">Atmosphere-only test with Held Suarez simple physics. Exact restart tests that uses half the PEs when restarted</option>
+    </options>
+  </test>
+  <test name="ERP_Ln9_P256_Vnuopc" grid="mpasa120_oQU120" compset="CHAOS2000dev" testmods="cam/outfrq9s_mpasa120" >
+    <machines>
+      <machine name="derecho" compiler="nvhpc" category="ew-pr-restart"/>
+      <machine name="derecho" compiler="intel" category="ew-pr-restart"/>
+      <machine name="derecho" compiler="gnu"   category="ew-pr-restart"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 02:00:00 </option>
+      <option name="comment">EarthWorks model with active mpasa, mpaso, mpassi using cam_dev physics. Exact restart tests that uses half the PEs when restarted</option>
+    </options>
+  </test>
   <test name="SMS_P128_Vnuopc" grid="mpasa120z32_mpasa120" compset="FHS94" >
     <machines>
       <machine name="derecho" compiler="nvhpc" category="ew-pr"/>


### PR DESCRIPTION
Use the newest nvhpc/24.9 stack on Derecho by updating ccs_configs. Since nvhpc/24.9 fixes a restart issue with CAM-MPAS, tests are added to check restarts with the FHS94 and CHAOS2000dev compsets in the `ew-pr` category.

This PR fixes #21 