### PR TITLE
Re-enable MPAS-A OpenACC, improve GPU answer differences.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,9 +57,9 @@
 
 [submodule "cam"]
         path = components/cam
-        url = https://www.github.com/EarthWorksOrg/CAM
+        url = https://www.github.com/gdicker1/CAM
         fxDONOTUSEurl = https://www.github.com/ESCOMP/CAM
-        fxtag = cam-ew2.3.006
+        fxtag = fix/mpasa_ansdiffs_cpu
         fxrequired = ToplevelRequired
 
 [submodule "clm"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -57,9 +57,9 @@
 
 [submodule "cam"]
         path = components/cam
-        url = https://www.github.com/gdicker1/CAM
+        url = https://www.github.com/EarthWorksOrg/CAM
         fxDONOTUSEurl = https://www.github.com/ESCOMP/CAM
-        fxtag = fix/mpasa-oacc_ansdiffs
+        fxtag = cam-ew2.3.008
         fxrequired = ToplevelRequired
 
 [submodule "clm"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -59,7 +59,7 @@
         path = components/cam
         url = https://www.github.com/gdicker1/CAM
         fxDONOTUSEurl = https://www.github.com/ESCOMP/CAM
-        fxtag = fix/mpasa_ansdiffs_cpu
+        fxtag = fix/mpasa-oacc_ansdiffs
         fxrequired = ToplevelRequired
 
 [submodule "clm"]


### PR DESCRIPTION
This PR brings switches the mpas external in CAM to use an updated OpenACC version that works for simple physics compsets. This re-enables MPAS-A OpenACC that was removed in #57.

More complicated test cases on GPUs like F2000climo and CHAOS2000dev now fail to complete with these changes. Answers beginning diverging from previous results and the runs either fail to finish within allotted time or crash due to "NaN detected in the 'w' field". These compsets successfully complete on GPUs if the CPU-only [ew-develop-noacc](https://github.com/EarthWorksOrg/MPAS-Model/tree/ew-develop-noacc) MPAS-A branch is used instead.

CPU results are unaffected in CAM-MPAS with these changes.