### PR TITLE
Revert to nvhpc/24.3 software stack on Derecho

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,7 @@
         path = ccs_config
         url = https://github.com/gdicker1/ccs_config_cesm.git
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        fxtag = revert/derecho_nvhpc249
+        fxtag = ccs_config-ew2.3.007
         fxrequired = ToplevelRequired
 
 [submodule "cime"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,9 @@
 
 [submodule "ccs_config"]
         path = ccs_config
-        url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+        url = https://github.com/gdicker1/ccs_config_cesm.git
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        fxtag = ccs_config-ew2.3.006
+        fxtag = revert/derecho_nvhpc249
         fxrequired = ToplevelRequired
 
 [submodule "cime"]


### PR DESCRIPTION
Basically reverts PR #80. This PR closes #90, but would re-open #21 since nvhpc/24.9 fixes restartability. 