### PR TITLE
Fix loop bounds in EWOrg/MPAS-Model for DEBUG=true runs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,9 +57,11 @@
 
 [submodule "cam"]
         path = components/cam
-        url = https://www.github.com/EarthWorksOrg/CAM
+        # url = https://www.github.com/EarthWorksOrg/CAM
+        url = https://www.github.com/gdicker1/CAM
         fxDONOTUSEurl = https://www.github.com/ESCOMP/CAM
-        fxtag = cam-ew2.4.002
+        # fxtag = cam-ew2.4.002
+        fxtag = fix/mpasa_gpu_tend_physics_loopbounds
         fxrequired = ToplevelRequired
 
 [submodule "clm"]


### PR DESCRIPTION
Fixes loop bounds that cause CAM-MPAS runs in EarthWorks to fail if built with DEBUG=true. This applies to CPU and GPU runs.

Closes #103.