### PR TITLE
Update EW compsets, use CLM60 in F2000dev-like compsets

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -123,33 +123,34 @@
   <!-- EarthWorks specific compsets
        MPAS-ocean and/or MPAS-seaice couplings -->
 
-  <!-- F2000climo, with MPASSI%PRES -->
+  <!-- like F2000dev from CAM, with MPASSI prescribed mode -->
+  <compset>
+    <alias>F2000devEW</alias>
+    <lname>2000_CAM70_CLM60%SP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <!-- like F2000dev, with MPASSI and MPASO active -->
+  <compset>
+     <alias>CHAOS2000dev</alias>
+     <lname>2000_CAM70_CLM60%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <!-- like F2000climo, with MPASSI prescribed mode -->
   <compset>
      <alias>F2000climoEW</alias>
      <lname>2000_CAM60_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
-  <!-- F2000dev, with MPASSI%PRES -->
-  <compset>
-    <alias>F2000devEW</alias>
-    <lname>2000_CAM70_CLM50%SP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-  </compset>
-
+  <!-- like F2000climo, with MPASSI and MPASO -->
   <compset>
       <alias>FullyCoupledEW</alias>
       <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_SROF_SGLC_SWAV</lname>
   </compset>
 
-  <!-- Like FullyCoupledEW, but with MOSART river -->
+  <!-- Like FullyCoupledEW, with MOSART river active too -->
   <compset>
      <alias>CHAOS2000</alias>
      <lname>2000_CAM60_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <!-- Use cam_dev / CAM7 physics instead -->
-  <compset>
-     <alias>CHAOS2000dev</alias>
-     <lname>2000_CAM70_CLM50%SP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
   </compset>
   <!-- END EarthWorks specific compsets -->
 


### PR DESCRIPTION
At ewm-2.4.006 we are based on cesm3_0_beta05 which allows CAM70 and CLM50%SP to be used together. Updating to cesm3_0_beta06 showed an incompatibility with dust emission settings for compsets defined with '..._CAM70_CLM50%SP...' that prevents cases/tests from completing `case.setup`.

Our compsets that nominally track F2000dev have had a different land version for a while, this PR addresses that.