### PR TITLE
Better align EWOrg/CAM with upstream tag cam6_4_048

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,11 +57,9 @@
 
 [submodule "cam"]
         path = components/cam
-        # url = https://www.github.com/EarthWorksOrg/CAM
-        url = https://www.github.com/gdicker1/CAM
+        url = https://www.github.com/EarthWorksOrg/CAM
         fxDONOTUSEurl = https://www.github.com/ESCOMP/CAM
-        # fxtag = cam-ew2.4.003
-        fxtag = align-eworg-w-cam6_4_048
+        fxtag = cam-ew2.4.004
         fxrequired = ToplevelRequired
 
 [submodule "clm"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -57,9 +57,11 @@
 
 [submodule "cam"]
         path = components/cam
-        url = https://www.github.com/EarthWorksOrg/CAM
+        # url = https://www.github.com/EarthWorksOrg/CAM
+        url = https://www.github.com/gdicker1/CAM
         fxDONOTUSEurl = https://www.github.com/ESCOMP/CAM
-        fxtag = cam-ew2.4.003
+        # fxtag = cam-ew2.4.003
+        fxtag = align-eworg-w-cam6_4_048
         fxrequired = ToplevelRequired
 
 [submodule "clm"]


### PR DESCRIPTION
CAM is updated in this PR to remove changes associated with EarthWorks-specific PRs.