### PR TITLE
30km ocean files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,14 +30,14 @@
         path = ccs_config
         url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        fxtag = release-ccs_config-ew2.5
+        fxtag = ccs_config-ew2.5.000
         fxrequired = ToplevelRequired
 
 [submodule "cime"]
         path = cime
         url = https://github.com/EarthWorksOrg/cime
         fxDONOTUSEurl = https://github.com/ESMCI/cime
-        fxtag = release-cime-ew2.5
+        fxtag = cime-ew2.5.000
         fxrequired = ToplevelRequired
 
 # EarthWorks is not using fms
@@ -59,7 +59,7 @@
         path = components/cam
         url = https://www.github.com/EarthWorksOrg/CAM
         fxDONOTUSEurl = https://www.github.com/ESCOMP/CAM
-        fxtag = release-cam-ew2.5
+        fxtag = cam-ew2.5.000
         fxrequired = ToplevelRequired
 
 [submodule "clm"]
@@ -104,7 +104,7 @@
         url = https://github.com/EarthWorksOrg/CMEPS.git
         fxDONOTUSEurl = https://github.com/ESCOMP/CMEPS.git
         fxrequired = ToplevelRequired
-        fxtag = release-cmeps-ew2.5
+        fxtag = cmeps-ew2.5.000
 
 # EarthWorks is not using rtm
 # [submodule "rtm"]
@@ -164,21 +164,21 @@
         url = https://github.com/EarthWorksOrg/mpas-ocean.git
         fxDONOTUSEurl = https://github.com/EarthWorksOrg/mpas-ocean.git
         fxrequired = ToplevelRequired
-        fxtag = release-mpaso-ew2.5
+        fxtag = mpaso-ew2.5.000
 
 [submodule "mpas-seaice"]
         path = components/mpas-seaice
         url = https://github.com/EarthWorksOrg/mpas-seaice.git
         fxDONOTUSEurl = https://github.com/EarthWorksOrg/mpas-seaice.git
         fxrequired = ToplevelRequired
-        fxtag = release-mpassi-ew2.5
+        fxtag = mpassi-ew2.5.000
 
 [submodule "mpas-framework"]
         path = components/mpas-framework
         url = https://github.com/EarthWorksOrg/mpas-framework.git
         fxDONOTUSEurl = https://github.com/EarthWorksOrg/mpas-framework.git
         fxrequired = ToplevelRequired
-        fxtag = release-mpasfrwk-ew2.5
+        fxtag = mpasfrwk-ew2.5.000
 
 [submodule "ewms-diags"]
         path = tools/ewms-diags

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,8 @@
         path = ccs_config
         url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        fxtag = ccs_config-ew2.5.000
+        #fxtag = ccs_config-ew2.5.000
+        fxtag = 30km_ocean_files
         fxrequired = ToplevelRequired
 
 [submodule "cime"]
@@ -164,14 +165,16 @@
         url = https://github.com/EarthWorksOrg/mpas-ocean.git
         fxDONOTUSEurl = https://github.com/EarthWorksOrg/mpas-ocean.git
         fxrequired = ToplevelRequired
-        fxtag = mpaso-ew2.5.000
+        #fxtag = mpaso-ew2.5.000
+        fxtag = 30km_ocean_files
 
 [submodule "mpas-seaice"]
         path = components/mpas-seaice
         url = https://github.com/EarthWorksOrg/mpas-seaice.git
         fxDONOTUSEurl = https://github.com/EarthWorksOrg/mpas-seaice.git
         fxrequired = ToplevelRequired
-        fxtag = mpassi-ew2.5.000
+        #fxtag = mpassi-ew2.5.000
+        fxtag = 30km_ocean_files
 
 [submodule "mpas-framework"]
         path = components/mpas-framework


### PR DESCRIPTION
New 30km ocean files are now set as the default. The new files have had the domain adjusted so that seaice does not freeze the entire column.

Sub-PRs included are
mpas-ocean #21 
mpas-seaice #23
ccs_config_cesm #39

All sub-PRs involve the 30km_ocean_files branch.