### PR TITLE
Use NVHPC v24.11 stack on Derecho

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,11 +28,9 @@
 
 [submodule "ccs_config"]
         path = ccs_config
-        # url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
-        url = https://github.com/gdicker1/ccs_config_cesm.git
+        url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        # fxtag = ccs_config-ew2.5.001
-        fxtag = use_nvhpc_24.11
+        fxtag = ccs_config-ew2.5.002
         fxrequired = ToplevelRequired
 
 [submodule "cime"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,11 @@
 
 [submodule "ccs_config"]
         path = ccs_config
-        url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+        # url = https://github.com/EarthWorksOrg/ccs_config_cesm.git
+        url = https://github.com/gdicker1/ccs_config_cesm.git
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
-        fxtag = ccs_config-ew2.5.001
+        # fxtag = ccs_config-ew2.5.001
+        fxtag = use_nvhpc_24.11
         fxrequired = ToplevelRequired
 
 [submodule "cime"]


### PR DESCRIPTION
Revert changes made to EarthWorksOrg/ccs_config_cesm during the EarthWorks v2.5 release. After this PR, ccs_config_cesm will largely match its upstream.

This PR works best if merged alongside or before #124. Together, they show a marked reduction in memory used by EarthWorks runs compiled with NVHPC 24.9+ on Derecho.

Fixes #21 